### PR TITLE
add `search` to the site

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ theme:
     code: Roboto Mono
    
 plugins:
+  - search
   - mkdocstrings:
   - mkdocs-jupyter:
       ignore_h1_titles: true


### PR DESCRIPTION
This PR adds the `search` plugin to the site.

<img width="1240" alt="image" src="https://github.com/Jonathan-Adly/AgentRun/assets/31466137/6765fc70-138b-4550-beff-dec4bcc464a3">
